### PR TITLE
Use Windows 10 SDK for MSVC 2017 projects

### DIFF
--- a/generate/msvc2017/AcpiExec.vcxproj
+++ b/generate/msvc2017/AcpiExec.vcxproj
@@ -18,7 +18,7 @@
     <SccProjectName />
     <SccLocalPath />
     <ProjectGuid>{1C19430A-8836-4023-AC37-AAB1921220E6}</ProjectGuid>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Template|Win32'" Label="Configuration">

--- a/generate/msvc2017/AslCompiler.vcxproj
+++ b/generate/msvc2017/AslCompiler.vcxproj
@@ -18,7 +18,7 @@
     <SccProjectName />
     <SccLocalPath />
     <ProjectGuid>{66BE33E1-849A-42AB-AE4B-2ABBC13CB432}</ProjectGuid>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Template|Win32'" Label="Configuration">


### PR DESCRIPTION
## Summary
- use Windows 10 SDK instead of 8.1 for MSVC 2017 project files

## Testing
- `make -C generate/unix iasl` *(fails: flex: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689495837e4c8331a5ccc48f15bc05b1